### PR TITLE
Add more special characters

### DIFF
--- a/src/RJMUtilityFunctions.php
+++ b/src/RJMUtilityFunctions.php
@@ -444,11 +444,10 @@ function alternate_json_encode($a = false) {
 			return floatval(str_replace(",", ".", strval($a)));
 		}
 
+		// Replacing special chartacers:  It's dangerous to go alone! Take this - http://php.net/manual/en/regexp.reference.unicode.php
+		// And this: http://www.codeproject.com/Articles/37735/Searching-Modifying-and-Encoding-Text
 		if (is_string($a)) {
-			static $jsonReplaces = array(
-				array("\\", "/",  "\n", "\t", "\r", "\b", "\f", '"', "\0", "\v", "\e"), 
-				array('\\\\', '\\/', '\\n', '\\t', '\\r', '\\b', '\\f', '\"', '\u0000', '\u000b', '\u001b')
-			);
+			static $jsonReplaces = array(array("\\", "/", "\n", "\t", "\r", "\b", "\f", '"', "\0", "\v", "\e", "\p{Cc}"), array('\\\\', '\\/', '\\n', '\\t', '\\r', '\\b', '\\f', '\"', '\u0000', '\u000b','\u001b', '\u009b'));
 			return '"' . str_replace($jsonReplaces[0], $jsonReplaces[1], $a) . '"';
 		}
 		else


### PR DESCRIPTION
Related to this ticket
https://trello.com/c/fsuJOEDA/1678-club-shop-s-r-o-group-by-continuously-thinks

I added support for two more characters (\u001b and \u009b) and added some helpful comments for future explorers so that they may be saved from what I went through on this.

Resources:
http://php.net/manual/en/regexp.reference.unicode.php
http://www.codeproject.com/Articles/37735/Searching-Modifying-and-Encoding-Text
##### Functional test

Note:  I live edited this change on dash dev and it appeared to work for this issue
- Load this version and make sure nothing bad happens with normal charts in the category cache (the values populating the chart Group By dropdowns).
- Make sure there nothing else breaks with json encoding.
