### PR TITLE
Revise jsonreplaces

### DIFF
--- a/src/RJMUtilityFunctions.php
+++ b/src/RJMUtilityFunctions.php
@@ -435,8 +435,8 @@ function alternate_json_encode($a = false) {
 	// Replacing special chartacers:  It's dangerous to go alone! Take this - http://php.net/manual/en/regexp.reference.unicode.php
 	// And this: http://www.codeproject.com/Articles/37735/Searching-Modifying-and-Encoding-Text
 	$jsonReplaces = array(
-		array("\\", "/", "\n", "\t", "\r", "\b", "\f", '"', "\0", "\v", "\e", chr(194).chr(155)), 
-		array('\\\\', '\\/', '\\n', '\\t', '\\r', '\\b', '\\f', '\"', '\u0000', '\u000b','\u001b', '\u009b')
+		array("\\", "/", "\n", "\t", "\r", "\b", "\f", '"', "\0", "\v", "\e", chr(194).chr(155), chr(26), chr(1)),
+		array('\\\\', '\\/', '\\n', '\\t', '\\r', '\\b', '\\f', '\"', '\u0000', '\u000b','\u001b', '\u009b', '\u001a', '\u0001')
 	);
 
 	if (is_null($a))


### PR DESCRIPTION
Related to this ticket:
https://trello.com/c/fsuJOEDA/1678-club-shop-s-r-o-group-by-continuously-thinks

This removes the static designation from $jsonReplaces and moves it to the top of the function, allowing us to use the chr() function to match unusual characters.

I've written a unit test for special characters and it passes, but it's in the RJMetrics repo.
##### Unit Test

Check out this branch and move RJMUtilityFunctions.php to the RJMetrics repo
checkout branch aje_test_special_chars in RJMetrics and run
`phpunit --bootstrap=test/bootstrap.php test/util/AlternateJsonEncodeTest.php`
##### Functional Test

While you still have this copy of RJMUtilityFunctions.php in your RJMetrics repo, load dashboards, the chart builder, and group by various categories to test alternate_json_encode.
