### PR TITLE
Properly escape the ETX special character in alternate_json_encode

### DIFF
--- a/src/RJMUtilityFunctions.php
+++ b/src/RJMUtilityFunctions.php
@@ -435,8 +435,8 @@ function alternate_json_encode($a = false) {
 	// Replacing special chartacers:  It's dangerous to go alone! Take this - http://php.net/manual/en/regexp.reference.unicode.php
 	// And this: http://www.codeproject.com/Articles/37735/Searching-Modifying-and-Encoding-Text
 	$jsonReplaces = array(
-		array("\\", "/", "\n", "\t", "\r", "\b", "\f", '"', "\0", "\v", "\e", chr(194).chr(155), chr(26), chr(1), chr(31)),
-		array('\\\\', '\\/', '\\n', '\\t', '\\r', '\\b', '\\f', '\"', '\u0000', '\u000b','\u001b', '\u009b', '\u001a', '\u0001', '\u001f')
+		array("\\", "/", "\n", "\t", "\r", "\b", "\f", '"', "\0", "\v", "\e", chr(194).chr(155), chr(26), chr(1), chr(31), chr(3)),
+		array('\\\\', '\\/', '\\n', '\\t', '\\r', '\\b', '\\f', '\"', '\u0000', '\u000b','\u001b', '\u009b', '\u001a', '\u0001', '\u001f', '\u0003')
 	);
 
 	if (is_null($a))


### PR DESCRIPTION
When a json string contains the [ETX](http://en.wikipedia.org/wiki/End-of-text_character) special character, `alternate_json_encode` breaks. This branch fixes that issue, by properly escaping that character.
