### PR TITLE
Get stack trace string w/o arguments

### DIFF
--- a/src/RJMUtilityFunctions.php
+++ b/src/RJMUtilityFunctions.php
@@ -679,7 +679,7 @@ function array_get(array $arr, $key, $default = null) {
 }
 
 /**
- * This function optionally removes argument values from a function call in a stack
+ * This function optionally removes argument values from all function calls in a stack
  * trace. Whenever we log potentially sensitive stack traces, it is prudent to remove
  * argument values.
  */


### PR DESCRIPTION
**Description**
Spurred by [this ticket](https://trello.com/c/5lDkdPlZ/5192-secrets-visible-in-the-exception-logging-section-of-the-admin-panel), we need a way to get an exception's stack trace, but to optionally exclude the parameters, which may contain sensitive values (like pws).

**Functional Test**
- Cause a job exception to be thrown
- Set the `JobErrorDetails` stack trace of the job to be the return val of this fn
- Observe output with and without function args:

![args removed](https://cloud.githubusercontent.com/assets/1185129/5493273/3c30f34e-86b7-11e4-996b-551d916dd203.png)
![args present](https://cloud.githubusercontent.com/assets/1185129/5493274/3c30fce0-86b7-11e4-8717-a52871f192a3.png)
