### PR TITLE
Support use case where exception stack trace frame contains no 'file'

### DIFF
--- a/src/RJMUtilityFunctions.php
+++ b/src/RJMUtilityFunctions.php
@@ -688,8 +688,8 @@ function renderStackTrace($trace, $sanitize = true) {
 	$traceString = '';
 
 	foreach ($trace as $i => $stackFrame) {
-		$file = $stackFrame['file'];
-		$lineNum = $stackFrame['line'];
+		$file = isset($stackFrame['file']) ? $stackFrame['file'] : '[internal function]' ;
+		$lineNum = isset($stackFrame['line']) ? '(' . $stackFrame['line'] . ')' : '';
 		$classAndFunction = $stackFrame['class'] . $stackFrame['type'] . $stackFrame['function'];
 		$args = array();
 
@@ -714,7 +714,7 @@ function renderStackTrace($trace, $sanitize = true) {
 		}
 
 		$args = join(', ', $args);
-		$traceString .= "#{$i} {$file}({$lineNum}): {$classAndFunction}({$args})\n";
+		$traceString .= "#{$i} {$file}{$lineNum}: {$classAndFunction}({$args})\n";
 
 		if ($i === count($trace) - 1) {
 			$traceString .= '#' . count($trace) . ' {main}';


### PR DESCRIPTION
**Description**
There are instances when a stack trace frame may not specify a file/line number. This change will print "[internal function]" instead--this is the same behavior as `Exception::getTraceAsString()`:

```
#0 [internal function]: SomeClass->someMethod()
```

**Functional Test**
Throw an exception and observe no `Undefined index: file` error when file is not set
