### PR TITLE
Removes newlines from compact stack traces to make them compact enoug…

### DIFF
--- a/src/RJMUtilityFunctions.php
+++ b/src/RJMUtilityFunctions.php
@@ -43,10 +43,10 @@ function compactStackTrace($removeThisCall = true){
 	foreach ($dbg as $d){
 		foreach ($fields as $f)
 			$d[$f] =  nu($d[$f]) ?: 'N/A';
-		$r .= "\n:.:{$d['file']}:{$d['line']}  {$d['class']} -> {$d['function']}";
+		$r .= ":.:{$d['file']}:{$d['line']}  {$d['class']} -> {$d['function']}";
 	}
 		
-	$r .= "\n:.:\n";
+	$r .= ":.:";
 	return $r;
 }
 


### PR DESCRIPTION
…h to actually be considered one line in logstash.

The newlines were breaking the logstash parsing. I'm not sure if `:.:` is the best delimiter to break up lines of the stack trace but it was already there.